### PR TITLE
APP-3953 Fix formatting issue with italics in slack markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/slack-to-html",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Render Slack markdown as HTML",
   "main": "dist/bundle.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -390,7 +390,7 @@ const expandText = (text) => {
     italicOpeningPatternString,
     closingSpanPatternString,
     expandedTextAndWindows.windows,
-    { spacePadded: true, maxReplacements: 100 }
+    { maxReplacements: 100 }
   )
   expandedTextAndWindows = replaceInWindows(
     expandedTextAndWindows.text,

--- a/test/markdownTest.js
+++ b/test/markdownTest.js
@@ -47,6 +47,12 @@ describe('markdown', () => {
     it('should render an element', () => {
       escapeForSlackWithMarkdown('this is _italic_').should.equal('this is <span class="slack_italics">italic</span>')
     })
+
+    it("should render an element between quotes", () => {
+      escapeForSlackWithMarkdown('this is "_italic_"').should.equal(
+        'this is "<span class="slack_italics">italic</span>"'
+      );
+    });
   })
 
   describe('strikethrough', () => {


### PR DESCRIPTION
Add test for fixed bug case
Remove `spacePadded: true` attribute from italic markdown case